### PR TITLE
✨ Add userId to the Identity type

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gulp": "~4.0.0",
     "gulptraum": "~3.0.0",
     "gulptraum-typescript": "~2.0.0",
+    "jsonwebtoken": "~8.4.0",
     "tsconfig": "~7.0.0",
     "tslint": "~5.11.0",
     "typescript": "~3.1.6"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/http_contracts": "~2.3.0",
-    "@essential-projects/iam_contracts": "feature~refactor_socket_io_handling",
+    "@essential-projects/iam_contracts": "~3.4.0",
     "loggerhythm": "~3.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/http_contracts": "~2.3.0",
-    "@essential-projects/iam_contracts": "~3.3.0",
+    "@essential-projects/iam_contracts": "feature~refactor_socket_io_handling",
     "loggerhythm": "~3.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Contains the process engines' IAM related functions.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -1,9 +1,12 @@
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 export class Identity implements IIdentity {
-  public token: string;
 
-  constructor(token: string) {
+  public readonly token: string;
+  public readonly userId: string;
+
+  constructor(token: string, userId: string) {
     this.token = token;
+    this.userId = userId;
   }
 }

--- a/src/identity_service.ts
+++ b/src/identity_service.ts
@@ -1,5 +1,7 @@
+import * as jsonwebtoken from 'jsonwebtoken';
+
 import {BadRequestError} from '@essential-projects/errors_ts';
-import {IIdentity, IIdentityService} from '@essential-projects/iam_contracts';
+import {IIdentity, IIdentityService, TokenBody} from '@essential-projects/iam_contracts';
 
 import {Identity} from './identity';
 
@@ -11,7 +13,9 @@ export class IdentityService implements IIdentityService {
       throw new BadRequestError('Must provide a token by which to create an identity!');
     }
 
-    const identity: IIdentity = new Identity(token);
+    const decodedToken: TokenBody = <TokenBody> jsonwebtoken.decode(token);
+
+    const identity: IIdentity = new Identity(token, decodedToken.sub);
 
     return Promise.resolve(identity);
   }

--- a/src/identity_service.ts
+++ b/src/identity_service.ts
@@ -1,3 +1,4 @@
+import {BadRequestError} from '@essential-projects/errors_ts';
 import {IIdentity, IIdentityService} from '@essential-projects/iam_contracts';
 
 import {Identity} from './identity';
@@ -7,7 +8,7 @@ export class IdentityService implements IIdentityService {
   public getIdentity(token: string): Promise<IIdentity> {
 
     if (token === null) {
-      throw new Error('Cannot get Identity by token');
+      throw new BadRequestError('Must provide a token by which to create an identity!');
     }
 
     const identity: IIdentity = new Identity(token);


### PR DESCRIPTION
**Changes:**

1. Use `@essential-project/errors_ts` for throwing errors.
2. Add the `userId` property to the `Identity` type.
3. Use `jsonwebtoken` to decode a given token and retrieve the attached `sub` property. That property will be used as the identities `userId`.
    - This change allows us to remove all token decoding operations from the ConsumerApi and ManagementApi. These should now exclusively use the `IdentityService` and the `Identity` type provided by this package!
    - Centralizing token decoding also allows us to switch the IAM implementations.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/135

PR: #9

## How can others test the changes?

Identities created by the `IdentityService` will now include the `userId` as extracted from the token.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).