### PR TITLE
⚡️Add claim check caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/http_contracts": "^2.3.0",
-    "@essential-projects/iam_contracts": "^3.4.0",
+    "@essential-projects/iam_contracts": "feature~update_iam_service_config",
     "loggerhythm": "^3.0.3",
     "moment": "^2.24.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "prepare": "npm run build",
     "lint": "eslint src/*.ts",
     "lint-fix": "eslint --fix src/*.ts",
-    "test": ":"
+    "test": "ts-mocha -p ./tsconfig.json ./test/**/*.spec.ts"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/http_contracts": "^2.3.0",
     "@essential-projects/iam_contracts": "^3.4.0",
-    "loggerhythm": "^3.0.3"
+    "loggerhythm": "^3.0.3",
+    "moment": "^2.24.0"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,13 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
+    "@types/mocha": "^5.2.6",
     "@types/node": "^10.12.2",
     "eslint": "^5.16.0",
     "jsonwebtoken": "^8.4.0",
+    "mocha": "^6.0.0",
+    "should": "^13.2.3",
+    "ts-mocha": "^6.0.0",
     "tsconfig": "^7.0.0",
     "typescript": "^3.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -8,9 +8,17 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
+  "author": "5Minds IT-Solutions GmbH & Co. KG",
+  "maintainers": [
+    "Alexander Kasten <alexander.kasten@5minds.de>",
+    "Christian Werner <christian.werner@5minds.de>",
+    "René Föhring <rene.foehring@5minds.de>",
+    "Steffen Knaup <steffen.knaup@5minds.de>"
+  ],
   "contributors": [
-    "Sebastian Meier <sebastian.meier@5minds.de>",
-    "Christian Werner <christian.werner@5minds.de>"
+    "Christoph Gnip <christoph.gnip@5minds.de>",
+    "Robin Lenz <robin.lenz@5minds.de>",
+    "Sebastian Meier <sebastian.meier@5minds.de>"
   ],
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Contains the process engines' IAM related functions.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/http_contracts": "^2.3.0",
-    "@essential-projects/iam_contracts": "feature~update_iam_service_config",
+    "@essential-projects/iam_contracts": "^3.6.0",
     "loggerhythm": "^3.0.3",
     "moment": "^2.24.0"
   },

--- a/src/claim_check_cache.ts
+++ b/src/claim_check_cache.ts
@@ -49,7 +49,13 @@ export class ClaimCheckCache {
    */
   public enable(): void {
     this.config.enabled = true;
-    this.cleanupTimer = setInterval(this.removeOutdatedEntries, this.config.cleanupIntervalInSeconds * 1000);
+
+    // Fallback is 2 minutes
+    const intervalInMs = this.config && this.config.cleanupIntervalInSeconds
+      ? this.config.cleanupIntervalInSeconds * 1000
+      : 120000;
+
+    this.cleanupTimer = setInterval(this.removeOutdatedEntries, intervalInMs);
   }
 
   /**
@@ -64,9 +70,9 @@ export class ClaimCheckCache {
   /**
    * Caches the given claim check result for the given userId and claim name.
    *
-   * @param userId
-   * @param claimName
-   * @param hasClaim
+   * @param userId    The userId for which to cache a claim check result.
+   * @param claimName The name of the claim for which to cache a result.
+   * @param hasClaim  The result of the claim check to cache.
    */
   public add(userId: string, claimName: string, hasClaim: boolean): void {
 

--- a/src/claim_check_cache.ts
+++ b/src/claim_check_cache.ts
@@ -19,14 +19,14 @@ type Cache = {[userId: string]: CacheEntry}
 
 type CacheEntry = {[claimName: string]: CacheValue}
 
-type CacheValue = {
+export type CacheValue = {
   userHasClaim: boolean;
   lastCheckedAt: moment.Moment;
 }
 
 export type ClaimCacheConfig = {
   enabled: boolean;
-  cleanupIntervalInMinutes: number;
+  cleanupIntervalInSeconds: number;
 }
 
 export class ClaimCheckCache {
@@ -44,17 +44,113 @@ export class ClaimCheckCache {
     }
   }
 
+  /**
+   * Enables the cache and initializes periodic cleanup.
+   */
   public enable(): void {
-    this.cleanupTimer = setInterval(this.removeOutdatedEntries, this.config.cleanupIntervalInMinutes);
+    this.config.enabled = true;
+    this.cleanupTimer = setInterval(this.removeOutdatedEntries, this.config.cleanupIntervalInSeconds * 1000);
   }
 
+  /**
+   * Disables the cache and stops periodic cleanup.
+   */
   public disable(): void {
+    this.config.enabled = false;
     clearInterval(this.cleanupTimer);
+    this.clearEntireCache();
   }
 
+  /**
+   * Caches the given claim check result for the given userId and claim name.
+   *
+   * @param userId
+   * @param claimName
+   * @param hasClaim
+   */
   public add(userId: string, claimName: string, hasClaim: boolean): void {
+
+    if (!this.config.enabled) {
+      return;
+    }
+
+    const userIdNotYetCached = !this.cache[userId];
+    if (userIdNotYetCached) {
+      this.cache[userId] = {};
+    }
+
+    const claimNotCached = !this.hasMatchingEntry(userId, claimName);
+
+    if (claimNotCached) {
+      this.cache[userId][claimName] = {
+        userHasClaim: hasClaim,
+        lastCheckedAt: moment(),
+      };
+    } else {
+      this.cache[userId][claimName].userHasClaim = hasClaim;
+      this.cache[userId][claimName].lastCheckedAt = moment();
+    }
   }
 
-  private removeOutdatedEntries(): void {}
+  /**
+   * Retrieves the cached check result for the given UserId and claim name.
+   *
+   * @param   userId    The UserId for which to get the claim check.
+   * @param   claimName The name of the claim for which to get the cached
+   *                    check result.
+   * @returns           The cached claim check result, or "undefind",
+   *                    if no matching cache entry exists.
+   */
+  public get(userId: string, claimName: string): CacheValue {
+    if (!this.hasMatchingEntry(userId, claimName)) {
+      return undefined;
+    }
+
+    return this.cache[userId][claimName];
+  }
+
+  /**
+   * Checks if the cache contains a result for the given userId and claim name.
+   *
+   * @param   userId    The UserId for which to get the claim check.
+   * @param   claimName The name of the claim for which to check if a cached
+   *                    result exists.
+   * @returns           "True", if the cache has a matching entry;
+   *                    otherwise "false".
+   */
+  public hasMatchingEntry(userId: string, claimName: string): boolean {
+    return this.cache[userId] !== undefined &&
+           this.cache[userId][claimName] !== undefined;
+  }
+
+  private removeOutdatedEntries(): void {
+
+    const cachedUserIds = Object.keys(this.cache);
+
+    const now = moment();
+
+    for (const userId of cachedUserIds) {
+
+      const cachedUser = this.cache[userId];
+
+      const cachedClaimsForUser = Object.keys(cachedUser);
+      for (const claimName of cachedClaimsForUser) {
+
+        const claim = cachedUser[claimName];
+
+        const cacheEntryIsOutdated = now.isAfter(claim.lastCheckedAt);
+        if (cacheEntryIsOutdated) {
+          delete cachedUser[claimName];
+        }
+      }
+    }
+  }
+
+  private clearEntireCache(): void {
+    const cachedUserIds = Object.keys(this.cache);
+    for (const userId of cachedUserIds) {
+      delete this.cache[userId];
+    }
+  }
 
 }

--- a/src/claim_check_cache.ts
+++ b/src/claim_check_cache.ts
@@ -71,11 +71,13 @@ export class ClaimCheckCache {
 
     this.isEnabled = true;
 
-    const intervalInMs = this.config.cleanupIntervalInSeconds
+    const intervalInMs = this.config.cleanupIntervalInSeconds !== undefined
       ? this.config.cleanupIntervalInSeconds * 1000
       : this.defaultConfig.cleanupIntervalInSeconds * 1000;
 
-    const cacheLifeTimeInSeconds = this.config.cacheLifetimeInSeconds || this.defaultConfig.cacheLifetimeInSeconds;
+    const cacheLifeTimeInSeconds = this.config.cacheLifetimeInSeconds !== undefined
+      ? this.config.cacheLifetimeInSeconds
+      : this.defaultConfig.cacheLifetimeInSeconds;
 
     const cachedValuesDoNotExpire = intervalInMs === 0 || cacheLifeTimeInSeconds === 0;
     if (cachedValuesDoNotExpire) {

--- a/src/claim_check_cache.ts
+++ b/src/claim_check_cache.ts
@@ -45,7 +45,7 @@ export class ClaimCheckCache {
     const defaultConfig: ClaimCacheConfig = {
       enabled: true,
       cacheLifetimeInSeconds: 300,
-      cleanupIntervalInSeconds: 120,
+      cleanupIntervalInSeconds: 10,
     };
 
     this.config = config || defaultConfig;
@@ -74,7 +74,7 @@ export class ClaimCheckCache {
     // Fallback is 2 minutes
     const intervalInMs = this.config && this.config.cleanupIntervalInSeconds
       ? this.config.cleanupIntervalInSeconds * 1000
-      : 120000;
+      : 10000;
 
     this.cleanupTimer = setInterval(this.removeOutdatedEntries, intervalInMs);
   }

--- a/src/claim_check_cache.ts
+++ b/src/claim_check_cache.ts
@@ -84,7 +84,7 @@ export class ClaimCheckCache {
       return;
     }
 
-    this.cleanupTimer = setInterval(this.removeOutdatedEntries, intervalInMs);
+    this.cleanupTimer = setInterval(this.removeOutdatedEntries.bind(this), intervalInMs);
   }
 
   /**

--- a/src/claim_check_cache.ts
+++ b/src/claim_check_cache.ts
@@ -26,6 +26,7 @@ export type CacheValue = {
 
 export type ClaimCacheConfig = {
   enabled: boolean;
+  cacheLifetimeInSeconds: number;
   cleanupIntervalInSeconds: number;
 }
 
@@ -43,6 +44,7 @@ export class ClaimCheckCache {
 
     const defaultConfig: ClaimCacheConfig = {
       enabled: true,
+      cacheLifetimeInSeconds: 300,
       cleanupIntervalInSeconds: 120,
     };
 
@@ -168,7 +170,10 @@ export class ClaimCheckCache {
 
         const claim = cachedUser[claimName];
 
-        const cacheEntryIsOutdated = now.isAfter(claim.lastCheckedAt);
+        const cacheLifeTimeInSeconds = this.config.cacheLifetimeInSeconds || 300;
+        const cacheValueExpirationTime = claim.lastCheckedAt.add(cacheLifeTimeInSeconds, 'second');
+
+        const cacheEntryIsOutdated = now.isAfter(cacheValueExpirationTime);
         if (cacheEntryIsOutdated) {
           delete cachedUser[claimName];
         }

--- a/src/claim_check_cache.ts
+++ b/src/claim_check_cache.ts
@@ -21,7 +21,7 @@ type CacheEntry = {[claimName: string]: CacheValue}
 
 export type CacheValue = {
   userHasClaim: boolean;
-  lastCheckedAt: moment.Moment;
+  lastCheckedAt: string;
 }
 
 export type ClaimCacheConfig = {
@@ -127,11 +127,11 @@ export class ClaimCheckCache {
     if (claimNotCached) {
       this.cache[userId][claimName] = {
         userHasClaim: hasClaim,
-        lastCheckedAt: moment(),
+        lastCheckedAt: moment().toISOString(),
       };
     } else {
       this.cache[userId][claimName].userHasClaim = hasClaim;
-      this.cache[userId][claimName].lastCheckedAt = moment();
+      this.cache[userId][claimName].lastCheckedAt = moment().toISOString();
     }
   }
 
@@ -188,7 +188,7 @@ export class ClaimCheckCache {
 
         const claim = cachedUser[claimName];
 
-        const cacheValueExpirationTime = claim.lastCheckedAt.add(cacheLifeTimeInSeconds, 'second');
+        const cacheValueExpirationTime = moment(claim.lastCheckedAt).add(cacheLifeTimeInSeconds, 'second');
 
         const cacheEntryIsOutdated = now.isAfter(cacheValueExpirationTime);
         if (cacheEntryIsOutdated) {

--- a/src/claim_check_cache.ts
+++ b/src/claim_check_cache.ts
@@ -37,6 +37,8 @@ export class ClaimCheckCache {
 
   private cleanupTimer: NodeJS.Timeout;
 
+  private isEnabled = false;
+
   constructor(config: ClaimCacheConfig) {
 
     const defaultConfig: ClaimCacheConfig = {
@@ -51,10 +53,21 @@ export class ClaimCheckCache {
   }
 
   /**
+   * Returns the current enabled-status of the cache.
+   */
+  public get enabled(): boolean {
+    return this.isEnabled;
+  }
+
+  /**
    * Enables the cache and initializes periodic cleanup.
    */
   public enable(): void {
-    this.config.enabled = true;
+    if (this.isEnabled) {
+      return;
+    }
+
+    this.isEnabled = true;
 
     // Fallback is 2 minutes
     const intervalInMs = this.config && this.config.cleanupIntervalInSeconds
@@ -68,7 +81,11 @@ export class ClaimCheckCache {
    * Disables the cache and stops periodic cleanup.
    */
   public disable(): void {
-    this.config.enabled = false;
+    if (!this.isEnabled) {
+      return;
+    }
+
+    this.isEnabled = false;
     clearInterval(this.cleanupTimer);
     this.clearEntireCache();
   }
@@ -82,7 +99,7 @@ export class ClaimCheckCache {
    */
   public add(userId: string, claimName: string, hasClaim: boolean): void {
 
-    if (!this.config.enabled) {
+    if (!this.isEnabled) {
       return;
     }
 

--- a/src/claim_check_cache.ts
+++ b/src/claim_check_cache.ts
@@ -38,7 +38,13 @@ export class ClaimCheckCache {
   private cleanupTimer: NodeJS.Timeout;
 
   constructor(config: ClaimCacheConfig) {
-    this.config = config;
+
+    const defaultConfig: ClaimCacheConfig = {
+      enabled: true,
+      cleanupIntervalInSeconds: 120,
+    };
+
+    this.config = config || defaultConfig;
     if (this.config.enabled) {
       this.enable();
     }

--- a/src/claim_check_cache.ts
+++ b/src/claim_check_cache.ts
@@ -88,6 +88,7 @@ export class ClaimCheckCache {
     this.isEnabled = false;
     clearInterval(this.cleanupTimer);
     this.clearEntireCache();
+    this.cleanupTimer = undefined;
   }
 
   /**

--- a/src/claim_check_cache.ts
+++ b/src/claim_check_cache.ts
@@ -1,0 +1,60 @@
+import * as moment from 'moment';
+
+/**
+ * Structure looks like:
+ * {
+ *   userId: {
+ *     claim1: {
+ *       userHasClaim: true,
+ *       lastCheckedAt: '2019-07-01T09:11:13.000Z'
+ *     },
+ *     claim2: {
+ *       userHasClaim: false,
+ *       lastCheckedAt: '2019-07-01T09:12:16.000Z'
+ *     },
+ *   }
+ * }
+ */
+type Cache = {[userId: string]: CacheEntry}
+
+type CacheEntry = {[claimName: string]: CacheValue}
+
+type CacheValue = {
+  userHasClaim: boolean;
+  lastCheckedAt: moment.Moment;
+}
+
+export type ClaimCacheConfig = {
+  enabled: boolean;
+  cleanupIntervalInMinutes: number;
+}
+
+export class ClaimCheckCache {
+
+  private config: ClaimCacheConfig;
+
+  private readonly cache: Cache = {};
+
+  private cleanupTimer: NodeJS.Timeout;
+
+  constructor(config: ClaimCacheConfig) {
+    this.config = config;
+    if (this.config.enabled) {
+      this.enable();
+    }
+  }
+
+  public enable(): void {
+    this.cleanupTimer = setInterval(this.removeOutdatedEntries, this.config.cleanupIntervalInMinutes);
+  }
+
+  public disable(): void {
+    clearInterval(this.cleanupTimer);
+  }
+
+  public add(userId: string, claimName: string, hasClaim: boolean): void {
+  }
+
+  private removeOutdatedEntries(): void {}
+
+}

--- a/src/iam_service.ts
+++ b/src/iam_service.ts
@@ -63,6 +63,8 @@ export class IAMService implements IIAMService {
 
     const resultFromAuthority = await this.getFromAuthority(identity.token, claimName, claimValue);
 
+    this.cache.add(identity.userId, claimName, resultFromAuthority);
+
     return resultFromAuthority;
   }
 
@@ -95,7 +97,7 @@ export class IAMService implements IIAMService {
 
     const response = await this.httpClient.get<any>(url, requestAuthHeaders);
 
-    return response.status !== this.httpResponseOkNoContentCode;
+    return response.status === this.httpResponseOkNoContentCode;
   }
 
 }

--- a/src/iam_service.ts
+++ b/src/iam_service.ts
@@ -96,9 +96,13 @@ export class IAMService implements IIAMService {
       url += `?claimValue=${claimValue}`;
     }
 
-    const response = await this.httpClient.get<any>(url, requestAuthHeaders);
+    try {
+      const response = await this.httpClient.get(url, requestAuthHeaders);
 
-    return response.status === this.httpResponseOkNoContentCode;
+      return response.status === this.httpResponseOkNoContentCode;
+    } catch (error) {
+      return false;
+    }
   }
 
 }

--- a/src/iam_service.ts
+++ b/src/iam_service.ts
@@ -2,15 +2,25 @@ import {BadRequestError, ForbiddenError} from '@essential-projects/errors_ts';
 import {IHttpClient} from '@essential-projects/http_contracts';
 import {IIAMConfiguration, IIAMService, IIdentity} from '@essential-projects/iam_contracts';
 
+import {CacheValue, ClaimCheckCache} from './claim_check_cache';
+
 export class IAMService implements IIAMService {
 
   private httpClient: IHttpClient;
   private config: IIAMConfiguration;
 
+  private cache: ClaimCheckCache;
+
   private httpResponseOkNoContentCode: number = 204;
 
   constructor(httpClient: IHttpClient) {
     this.httpClient = httpClient;
+  }
+
+  public async initialize(): Promise<void> {
+    // TODO: Update @essential-projects/iam_contracts IIAMConfiguration type.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.cache = new ClaimCheckCache((this.config as any).cache);
   }
 
   public async ensureHasClaim(identity: IIdentity, claimName: string, claimValue?: string): Promise<void> {
@@ -20,10 +30,9 @@ export class IAMService implements IIAMService {
     }
 
     if (!identity) {
-      throw new BadRequestError('No valid identity given');
+      throw new BadRequestError('No valid identity given!');
     }
 
-    // TODO: The dummy token check needs to be removed in the future!!
     try {
       const isDummyToken = Buffer.from(identity.token, 'base64').toString() === 'dummy_token';
       if (isDummyToken) {
@@ -34,12 +43,47 @@ export class IAMService implements IIAMService {
     }
 
     if (!claimName || claimName === '') {
-      throw new BadRequestError('No valid claimName given');
+      throw new BadRequestError('No valid claimName given!');
     }
+
+    const userHasClaim = await this.checkIfUserHasClaim(identity, claimName, claimValue);
+
+    if (!userHasClaim) {
+      throw new ForbiddenError('Identity does not have the requested claim!');
+    }
+  }
+
+  private async checkIfUserHasClaim(identity: IIdentity, claimName: string, claimValue?: string): Promise<boolean> {
+
+    const resultFromCache = this.getFromCache(identity.userId, claimName);
+
+    if (resultFromCache !== undefined) {
+      return resultFromCache.userHasClaim;
+    }
+
+    const resultFromAuthority = await this.getFromAuthority(identity.token, claimName, claimValue);
+
+    return resultFromAuthority;
+  }
+
+  private getFromCache(userId: string, claimName: string): CacheValue {
+
+    if (!this.cache.enabled) {
+      return undefined;
+    }
+
+    if (!this.cache.hasMatchingEntry(userId, claimName)) {
+      return undefined;
+    }
+
+    return this.cache.get(userId, claimName);
+  }
+
+  private async getFromAuthority(token: string, claimName: string, claimValue?: string): Promise<boolean> {
 
     const requestAuthHeaders = {
       headers: {
-        Authorization: `Bearer ${identity.token}`,
+        Authorization: `Bearer ${token}`,
       },
     };
 
@@ -51,9 +95,7 @@ export class IAMService implements IIAMService {
 
     const response = await this.httpClient.get<any>(url, requestAuthHeaders);
 
-    if (response.status !== this.httpResponseOkNoContentCode) {
-      throw new ForbiddenError('Identity does not have the requested claim!');
-    }
+    return response.status !== this.httpResponseOkNoContentCode;
   }
 
 }

--- a/src/iam_service.ts
+++ b/src/iam_service.ts
@@ -18,9 +18,10 @@ export class IAMService implements IIAMService {
   }
 
   public async initialize(): Promise<void> {
-    // TODO: Update @essential-projects/iam_contracts IIAMConfiguration type.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.cache = new ClaimCheckCache((this.config as any).cache);
+    const cacheConfigToUse = this.config && this.config.cache
+      ? this.config.cache
+      : undefined;
+    this.cache = new ClaimCheckCache(cacheConfigToUse);
   }
 
   public async ensureHasClaim(identity: IIdentity, claimName: string, claimValue?: string): Promise<void> {

--- a/src/identity_service.ts
+++ b/src/identity_service.ts
@@ -13,7 +13,6 @@ export class IdentityService implements IIdentityService {
       throw new BadRequestError('Must provide a token by which to create an identity!');
     }
 
-    // TODO: The dummy token check needs to be removed in the future!!
     try {
       const isDummyToken = Buffer.from(token, 'base64').toString() === 'dummy_token';
       if (isDummyToken) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './claim_check_cache';
 export * from './iam_service';
 export * from './identity_service';
 export * from './identity';

--- a/test/claim_check_cache/add.spec.ts
+++ b/test/claim_check_cache/add.spec.ts
@@ -1,0 +1,39 @@
+// Note: The tests are accessing private variables, so we must use this type of notation.
+/* eslint-disable dot-notation */
+import * as should from 'should';
+
+import {ClaimCheckCache} from '../../dist/commonjs/claim_check_cache';
+
+describe('ClaimCheckCache.add()', (): void => {
+
+  it('Should add entries to an enabled cache', (): void => {
+    const configToUse = {
+      enabled: true,
+      cleanupIntervalInSeconds: 666,
+    };
+    const cache = new ClaimCheckCache(configToUse);
+
+    cache.add('userId', 'claim', true);
+
+    should(cache.enabled).be.true();
+    should.exist(cache['cache']['userId']);
+
+    should(cache['cache']['userId']['claim'].userHasClaim).be.true();
+
+    cache.disable();
+  });
+
+  it('Should not add entries to a disabled cache', (): void => {
+    const configToUse = {
+      enabled: false,
+      cleanupIntervalInSeconds: 120000,
+    };
+    const cache = new ClaimCheckCache(configToUse);
+
+    cache.add('userId', 'claim', true);
+
+    should(cache.enabled).be.false();
+    should.not.exist(cache['cache']['userId']);
+  });
+
+});

--- a/test/claim_check_cache/clear_entire_cache.spec.ts
+++ b/test/claim_check_cache/clear_entire_cache.spec.ts
@@ -34,8 +34,6 @@ describe('ClaimCheckCache.clearEntireCache()', (): void => {
     const cachedKeys = Object.keys(testCache['cache']);
 
     should(cachedKeys).have.length(0);
-
-    testCache.disable();
   });
 
 });

--- a/test/claim_check_cache/clear_entire_cache.spec.ts
+++ b/test/claim_check_cache/clear_entire_cache.spec.ts
@@ -1,0 +1,41 @@
+// Note: The tests are accessing private variables, so we must use this type of notation.
+/* eslint-disable dot-notation */
+import * as should from 'should';
+
+import {ClaimCheckCache} from '../../dist/commonjs/claim_check_cache';
+
+describe('ClaimCheckCache.clearEntireCache()', (): void => {
+
+  let testCache;
+
+  before((): void => {
+    const configToUse = {
+      enabled: true,
+      cleanupIntervalInSeconds: 666,
+    };
+
+    testCache = new ClaimCheckCache(configToUse);
+  });
+
+  after((): void => {
+    testCache.disable();
+  });
+
+  it('Should clear out all cache entries', (): void => {
+
+    testCache.add('userId', 'claim', true);
+    testCache.add('userId', 'claim1', true);
+    testCache.add('userId2', 'claim', true);
+    testCache.add('userId2', 'claim3', true);
+    testCache.add('userId3', 'claim4', true);
+
+    testCache.clearEntireCache();
+
+    const cachedKeys = Object.keys(testCache['cache']);
+
+    should(cachedKeys).have.length(0);
+
+    testCache.disable();
+  });
+
+});

--- a/test/claim_check_cache/constructor.spec.ts
+++ b/test/claim_check_cache/constructor.spec.ts
@@ -83,7 +83,7 @@ describe('ClaimCheckCache - new()', (): void => {
       const defaultConfig = {
         enabled: true,
         cacheLifetimeInSeconds: 300,
-        cleanupIntervalInSeconds: 120,
+        cleanupIntervalInSeconds: 10,
       };
 
       should(cache.enabled).be.true();

--- a/test/claim_check_cache/constructor.spec.ts
+++ b/test/claim_check_cache/constructor.spec.ts
@@ -1,0 +1,102 @@
+// Note: The tests are accessing private variables, so we must use this type of notation.
+/* eslint-disable dot-notation */
+import * as should from 'should';
+
+import {ClaimCheckCache} from '../../dist/commonjs/claim_check_cache';
+
+describe('ClaimCheckCache - new()', (): void => {
+
+  describe('Use given config', (): void => {
+
+    it('Should not auto-start the cache, when config.enabled == false', (): void => {
+      const configToUse = {
+        enabled: false,
+        cleanupIntervalInSeconds: 120000,
+      };
+      const cache = new ClaimCheckCache(configToUse);
+
+      should(cache.enabled).be.false();
+      should(cache['config']).be.eql(configToUse);
+    });
+
+    it('Should not throw an error, when adding entries to a disabled cache', (): void => {
+      const configToUse = {
+        enabled: false,
+        cleanupIntervalInSeconds: 120000,
+      };
+      const cache = new ClaimCheckCache(configToUse);
+
+      cache.add('userId', 'claim', true);
+
+      should(cache.enabled).be.false();
+    });
+
+    it('Should not add entries to a disabled cache', (): void => {
+      const configToUse = {
+        enabled: false,
+        cleanupIntervalInSeconds: 120000,
+      };
+      const cache = new ClaimCheckCache(configToUse);
+
+      cache.add('userId', 'claim', true);
+
+      should(cache.enabled).be.false();
+      should.not.exist(cache['cache']['userId']);
+    });
+
+    it('Should auto-start the cache, when config.enabled == true', (): void => {
+      const configToUse = {
+        enabled: true,
+        cleanupIntervalInSeconds: 666,
+      };
+      const cache = new ClaimCheckCache(configToUse);
+
+      should(cache.enabled).be.true();
+      should(cache['config']).be.eql(configToUse);
+    });
+
+    it('Should add entries to an enabled cache', (): void => {
+      const configToUse = {
+        enabled: true,
+        cleanupIntervalInSeconds: 666,
+      };
+      const cache = new ClaimCheckCache(configToUse);
+
+      cache.add('userId', 'claim', true);
+
+      should(cache.enabled).be.true();
+      should.exist(cache['cache']['userId']);
+
+      should(cache['cache']['userId']['claim'].userHasClaim).be.true();
+    });
+  });
+
+  describe('Use fallback config', (): void => {
+
+    it('Should auto-start the cache', (): void => {
+      const cache = new ClaimCheckCache();
+
+      const defaultConfig = {
+        enabled: true,
+        cleanupIntervalInSeconds: 120,
+      };
+
+      should(cache.enabled).be.true();
+      should(cache['config']).be.eql(defaultConfig);
+
+    });
+
+    it('Should add entries to an enabled cache', (): void => {
+
+      const cache = new ClaimCheckCache();
+
+      cache.add('userId', 'claim', true);
+
+      should(cache.enabled).be.true();
+      should.exist(cache['cache']['userId']);
+
+      should(cache['cache']['userId']['claim'].userHasClaim).be.true();
+    });
+  });
+
+});

--- a/test/claim_check_cache/constructor.spec.ts
+++ b/test/claim_check_cache/constructor.spec.ts
@@ -82,6 +82,7 @@ describe('ClaimCheckCache - new()', (): void => {
 
       const defaultConfig = {
         enabled: true,
+        cacheLifetimeInSeconds: 300,
         cleanupIntervalInSeconds: 120,
       };
 

--- a/test/claim_check_cache/constructor.spec.ts
+++ b/test/claim_check_cache/constructor.spec.ts
@@ -53,6 +53,8 @@ describe('ClaimCheckCache - new()', (): void => {
 
       should(cache.enabled).be.true();
       should(cache['config']).be.eql(configToUse);
+
+      cache.disable();
     });
 
     it('Should add entries to an enabled cache', (): void => {
@@ -68,6 +70,8 @@ describe('ClaimCheckCache - new()', (): void => {
       should.exist(cache['cache']['userId']);
 
       should(cache['cache']['userId']['claim'].userHasClaim).be.true();
+
+      cache.disable();
     });
   });
 
@@ -84,6 +88,7 @@ describe('ClaimCheckCache - new()', (): void => {
       should(cache.enabled).be.true();
       should(cache['config']).be.eql(defaultConfig);
 
+      cache.disable();
     });
 
     it('Should add entries to an enabled cache', (): void => {
@@ -96,6 +101,8 @@ describe('ClaimCheckCache - new()', (): void => {
       should.exist(cache['cache']['userId']);
 
       should(cache['cache']['userId']['claim'].userHasClaim).be.true();
+
+      cache.disable();
     });
   });
 

--- a/test/claim_check_cache/disable.spec.ts
+++ b/test/claim_check_cache/disable.spec.ts
@@ -1,0 +1,60 @@
+// Note: The tests are accessing private variables, so we must use this type of notation.
+/* eslint-disable dot-notation */
+import * as should from 'should';
+
+import {ClaimCheckCache} from '../../dist/commonjs/claim_check_cache';
+
+describe('ClaimCheckCache.disable()', (): void => {
+
+  let testCache;
+
+  before((): void => {
+    const configToUse = {
+      enabled: false,
+      cleanupIntervalInSeconds: 1,
+    };
+
+    testCache = new ClaimCheckCache(configToUse);
+  });
+
+  it('Should stop the timer that periodically calls removeOutdatedEntries', async (): Promise<void> => {
+
+    let removeOutdatedEntriesCalled = false;
+
+    testCache.removeOutdatedEntries = (): void => {
+      removeOutdatedEntriesCalled = true;
+    };
+
+    testCache.enable();
+    testCache.disable();
+
+    await new Promise((resolve): void => { setTimeout(resolve, 1100); });
+
+    should(removeOutdatedEntriesCalled).be.false('removeOutdatedEntries was automatically called on a disabled cache!');
+
+  });
+
+  it('Should set the "enabled" flag to "false"', (): void => {
+    testCache.enable();
+    testCache.disable();
+    should(testCache.enabled).be.false();
+  });
+
+  it('Should ignore repeated calls, when the cache is already disabled', (): void => {
+    testCache.disable();
+    testCache.disable();
+    testCache.disable();
+    testCache.disable();
+  });
+
+  it('Should clear the entire cache, when disable is called', (): void => {
+    testCache.enable();
+    testCache.add('userId', 'claim', true);
+    testCache.disable();
+
+    const cachedKeys = Object.keys(testCache['cache']);
+
+    should(cachedKeys).have.length(0);
+  });
+
+});

--- a/test/claim_check_cache/disable.spec.ts
+++ b/test/claim_check_cache/disable.spec.ts
@@ -11,6 +11,7 @@ describe('ClaimCheckCache.disable()', (): void => {
   before((): void => {
     const configToUse = {
       enabled: false,
+      cacheLifetimeInSeconds: 10,
       cleanupIntervalInSeconds: 1,
     };
 

--- a/test/claim_check_cache/enable.spec.ts
+++ b/test/claim_check_cache/enable.spec.ts
@@ -27,8 +27,6 @@ describe('ClaimCheckCache.enable()', (): void => {
       testCache.removeOutdatedEntries = (): void => {
         should(testCache.enabled).be.true();
 
-        testCache.disable();
-
         resolve();
       };
 

--- a/test/claim_check_cache/enable.spec.ts
+++ b/test/claim_check_cache/enable.spec.ts
@@ -1,0 +1,52 @@
+// Note: The tests are accessing private variables, so we must use this type of notation.
+/* eslint-disable dot-notation */
+import * as should from 'should';
+
+import {ClaimCheckCache} from '../../dist/commonjs/claim_check_cache';
+
+describe('ClaimCheckCache.enable()', (): void => {
+
+  let testCache;
+
+  before((): void => {
+    const configToUse = {
+      enabled: false,
+      cleanupIntervalInSeconds: 1,
+    };
+
+    testCache = new ClaimCheckCache(configToUse);
+  });
+
+  afterEach((): void => {
+    testCache.disable();
+  });
+
+  it('Should create and start a timer that periodically calls removeOutdatedEntries', async (): Promise<void> => {
+
+    return new Promise((resolve, reject): void => {
+      testCache.removeOutdatedEntries = (): void => {
+        should(testCache.enabled).be.true();
+
+        testCache.disable();
+
+        resolve();
+      };
+
+      testCache.enable();
+    });
+  });
+
+  it('Should set the "enabled" flag to "true"', (): void => {
+    testCache.enable();
+    should(testCache.enabled).be.true();
+  });
+
+  it('Should ignore repeated calls, when the cache is already enabled', (): void => {
+    testCache.enable();
+    testCache.enable();
+    testCache.enable();
+    testCache.enable();
+    should(testCache.enabled).be.true();
+  });
+
+});

--- a/test/claim_check_cache/enable.spec.ts
+++ b/test/claim_check_cache/enable.spec.ts
@@ -46,7 +46,5 @@ describe('ClaimCheckCache.enable()', (): void => {
     testCache.enable();
     testCache.enable();
     testCache.enable();
-    should(testCache.enabled).be.true();
   });
-
 });

--- a/test/claim_check_cache/enable.spec.ts
+++ b/test/claim_check_cache/enable.spec.ts
@@ -6,43 +6,117 @@ import {ClaimCheckCache} from '../../dist/commonjs/claim_check_cache';
 
 describe('ClaimCheckCache.enable()', (): void => {
 
-  let testCache;
+  describe('Startup', (): void => {
 
-  before((): void => {
-    const configToUse = {
-      enabled: false,
-      cleanupIntervalInSeconds: 1,
-    };
+    let testCache;
 
-    testCache = new ClaimCheckCache(configToUse);
-  });
-
-  afterEach((): void => {
-    testCache.disable();
-  });
-
-  it('Should create and start a timer that periodically calls removeOutdatedEntries', async (): Promise<void> => {
-
-    return new Promise((resolve, reject): void => {
-      testCache.removeOutdatedEntries = (): void => {
-        should(testCache.enabled).be.true();
-
-        resolve();
+    before((): void => {
+      const configToUse = {
+        enabled: false,
+        cleanupIntervalInSeconds: 1,
       };
 
+      testCache = new ClaimCheckCache(configToUse);
+    });
+
+    afterEach((): void => {
+      testCache.disable();
+    });
+
+    it('Should set the "enabled" flag to "true"', (): void => {
+      testCache.enable();
+      should(testCache.enabled).be.true();
+    });
+
+    it('Should ignore repeated calls, when the cache is already enabled', (): void => {
+      testCache.enable();
+      testCache.enable();
+      testCache.enable();
       testCache.enable();
     });
   });
 
-  it('Should set the "enabled" flag to "true"', (): void => {
-    testCache.enable();
-    should(testCache.enabled).be.true();
+  describe('Transient cache', (): void => {
+
+    let testCache;
+
+    before((): void => {
+      const configToUse = {
+        enabled: false,
+        cleanupIntervalInSeconds: 1,
+      };
+
+      testCache = new ClaimCheckCache(configToUse);
+    });
+
+    afterEach((): void => {
+      testCache.disable();
+    });
+
+    it('Should create and start a timer that periodically calls removeOutdatedEntries', async (): Promise<void> => {
+
+      return new Promise((resolve, reject): void => {
+        testCache.removeOutdatedEntries = (): void => {
+          should(testCache.enabled).be.true();
+
+          resolve();
+        };
+
+        testCache.enable();
+      });
+    });
   });
 
-  it('Should ignore repeated calls, when the cache is already enabled', (): void => {
-    testCache.enable();
-    testCache.enable();
-    testCache.enable();
-    testCache.enable();
+  describe('Permanent cache', (): void => {
+
+    it('Should not call removeOutdatedEntries periodically, when cleanup interval is set to 0', async (): Promise<void> => {
+
+      const configToUse = {
+        enabled: false,
+        cacheLifetimeInSeconds: 1,
+        cleanupIntervalInSeconds: 0,
+      };
+
+      const testCache = new ClaimCheckCache(configToUse);
+
+      let removeOutdatedEntriesCalled = false;
+
+      testCache.removeOutdatedEntries = (): void => {
+        removeOutdatedEntriesCalled = true;
+      };
+
+      testCache.enable();
+
+      await new Promise((resolve): void => { setTimeout(resolve, 1100); });
+
+      should(removeOutdatedEntriesCalled).be.false();
+
+      testCache.disable();
+    });
+
+    it('Should not call removeOutdatedEntries periodically, when cache value lifetime is set to 0', async (): Promise<void> => {
+
+      const configToUse = {
+        enabled: false,
+        cacheLifetimeInSeconds: 0,
+        cleanupIntervalInSeconds: 1,
+      };
+
+      const testCache = new ClaimCheckCache(configToUse);
+
+      let removeOutdatedEntriesCalled = false;
+
+      testCache.removeOutdatedEntries = (): void => {
+        removeOutdatedEntriesCalled = true;
+      };
+
+      testCache.enable();
+
+      await new Promise((resolve): void => { setTimeout(resolve, 1100); });
+
+      should(removeOutdatedEntriesCalled).be.false();
+
+      testCache.disable();
+    });
   });
 });

--- a/test/claim_check_cache/get.spec.ts
+++ b/test/claim_check_cache/get.spec.ts
@@ -1,0 +1,46 @@
+// Note: The tests are accessing private variables, so we must use this type of notation.
+/* eslint-disable dot-notation */
+import * as should from 'should';
+
+import {ClaimCheckCache} from '../../dist/commonjs/claim_check_cache';
+
+describe('ClaimCheckCache.add()', (): void => {
+
+  let testCache;
+
+  before((): void => {
+    const configToUse = {
+      enabled: true,
+      cleanupIntervalInSeconds: 666,
+    };
+
+    testCache = new ClaimCheckCache(configToUse);
+  });
+
+  afterEach((): void => {
+    testCache['cache'] = {};
+  });
+
+  after((): void => {
+    testCache.disable();
+  });
+
+  it('Should get an existing entry from an enabled cache', (): void => {
+
+    testCache.add('userId', 'claim', true);
+
+    const cachedEntry = testCache.get('userId', 'claim');
+
+    should.exist(cachedEntry);
+    should(cachedEntry.userHasClaim).be.true();
+  });
+
+  it('Should return undefined, if the cache does not contain a matching entry', (): void => {
+
+    testCache.add('userId', 'claim', true);
+
+    const cachedEntry = testCache.get('userId2', 'claim');
+
+    should.not.exist(cachedEntry);
+  });
+});

--- a/test/claim_check_cache/has_matching_entry.spec.ts
+++ b/test/claim_check_cache/has_matching_entry.spec.ts
@@ -4,7 +4,7 @@ import * as should from 'should';
 
 import {ClaimCheckCache} from '../../dist/commonjs/claim_check_cache';
 
-describe('ClaimCheckCache.get()', (): void => {
+describe('ClaimCheckCache.hasMatchingEntry()', (): void => {
 
   let testCache;
 
@@ -25,22 +25,21 @@ describe('ClaimCheckCache.get()', (): void => {
     testCache.disable();
   });
 
-  it('Should get an existing entry from an enabled cache', (): void => {
+  it('Should return true, when the looked up value exists', (): void => {
 
     testCache.add('userId', 'claim', true);
 
-    const cachedEntry = testCache.get('userId', 'claim');
+    const exists = testCache.hasMatchingEntry('userId', 'claim');
 
-    should.exist(cachedEntry);
-    should(cachedEntry.userHasClaim).be.true();
+    should(exists).be.true();
   });
 
-  it('Should return undefined, if the cache does not contain a matching entry', (): void => {
+  it('Should return false, when the looked up value does not exist', (): void => {
 
     testCache.add('userId', 'claim', true);
 
-    const cachedEntry = testCache.get('userId2', 'claim');
+    const exists = testCache.hasMatchingEntry('userId2', 'claim');
 
-    should.not.exist(cachedEntry);
+    should(exists).be.false();
   });
 });

--- a/test/claim_check_cache/remove_outdated_entries.spec.ts
+++ b/test/claim_check_cache/remove_outdated_entries.spec.ts
@@ -7,63 +7,131 @@ import {ClaimCheckCache} from '../../dist/commonjs/claim_check_cache';
 
 describe('ClaimCheckCache.removeOutdatedEntries()', (): void => {
 
-  let testCache;
+  describe('Transient cache', (): void => {
 
-  before((): void => {
-    const configToUse = {
-      enabled: true,
-      cacheLifetimeInSeconds: 60,
-      cleanupIntervalInSeconds: 666,
-    };
+    let testCache;
 
-    testCache = new ClaimCheckCache(configToUse);
+    before((): void => {
+      const configToUse = {
+        enabled: true,
+        cacheLifetimeInSeconds: 60,
+        cleanupIntervalInSeconds: 666,
+      };
+
+      testCache = new ClaimCheckCache(configToUse);
+    });
+
+    after((): void => {
+      testCache.disable();
+    });
+
+    it('Should remove all values from the cache that are past the configured expiration time', (): void => {
+
+      const sampleCache = {
+        userId1: {
+          claim1: {
+            userHasClaim: true,
+            lastCheckedAt: moment().add(5, 'seconds'),
+          },
+          claim2: {
+            userHasClaim: false,
+            lastCheckedAt: moment().subtract(120, 'seconds'),
+          },
+        },
+        userId2: {
+          claim1: {
+            userHasClaim: true,
+            lastCheckedAt: moment().subtract(55, 'seconds'),
+          },
+          claim2: {
+            userHasClaim: false,
+            lastCheckedAt: moment(),
+          },
+          claim3: {
+            userHasClaim: false,
+            lastCheckedAt: moment().subtract(61, 'seconds'),
+          },
+        },
+      };
+
+      testCache['cache'] = sampleCache;
+
+      testCache.removeOutdatedEntries();
+
+      should.exist(testCache['cache']['userId1']);
+      should.exist(testCache['cache']['userId2']);
+
+      should.exist(testCache['cache']['userId1']['claim1']);
+      should.not.exist(testCache['cache']['userId1']['claim2']);
+
+      should.exist(testCache['cache']['userId2']['claim1']);
+      should.exist(testCache['cache']['userId2']['claim2']);
+      should.not.exist(testCache['cache']['userId2']['claim3']);
+    });
+
   });
 
-  after((): void => {
-    testCache.disable();
-  });
+  describe('Permanent cache', (): void => {
 
-  it('Should remove all values from the cache that are past the configured expiration time', (): void => {
+    let testCache;
 
-    const sampleCache = {
-      userId1: {
-        claim1: {
-          userHasClaim: true,
-          lastCheckedAt: moment().add(5, 'seconds'),
+    before((): void => {
+      const configToUse = {
+        enabled: true,
+        cacheLifetimeInSeconds: 0,
+        cleanupIntervalInSeconds: 1,
+      };
+
+      testCache = new ClaimCheckCache(configToUse);
+    });
+
+    after((): void => {
+      testCache.disable();
+    });
+
+    it('Should not remove any values from the cache, when the cache value lifetime is set to 0', (): void => {
+
+      const sampleCache = {
+        userId1: {
+          claim1: {
+            userHasClaim: true,
+            lastCheckedAt: moment().add(5, 'seconds'),
+          },
+          claim2: {
+            userHasClaim: false,
+            lastCheckedAt: moment().subtract(120, 'seconds'),
+          },
         },
-        claim2: {
-          userHasClaim: false,
-          lastCheckedAt: moment().subtract(120, 'seconds'),
+        userId2: {
+          claim1: {
+            userHasClaim: true,
+            lastCheckedAt: moment().subtract(55, 'seconds'),
+          },
+          claim2: {
+            userHasClaim: false,
+            lastCheckedAt: moment(),
+          },
+          claim3: {
+            userHasClaim: false,
+            lastCheckedAt: moment().subtract(61, 'seconds'),
+          },
         },
-      },
-      userId2: {
-        claim1: {
-          userHasClaim: true,
-          lastCheckedAt: moment().subtract(55, 'seconds'),
-        },
-        claim2: {
-          userHasClaim: false,
-          lastCheckedAt: moment(),
-        },
-        claim3: {
-          userHasClaim: false,
-          lastCheckedAt: moment().subtract(61, 'seconds'),
-        },
-      },
-    };
+      };
 
-    testCache['cache'] = sampleCache;
+      testCache['cache'] = sampleCache;
 
-    testCache.removeOutdatedEntries();
+      testCache.removeOutdatedEntries();
 
-    should.exist(testCache['cache']['userId1']);
-    should.exist(testCache['cache']['userId2']);
+      should.exist(testCache['cache']['userId1']);
+      should.exist(testCache['cache']['userId2']);
 
-    should.exist(testCache['cache']['userId1']['claim1']);
-    should.not.exist(testCache['cache']['userId1']['claim2']);
+      should.exist(testCache['cache']['userId1']['claim1']);
+      should.exist(testCache['cache']['userId1']['claim2']);
 
-    should.exist(testCache['cache']['userId2']['claim1']);
-    should.exist(testCache['cache']['userId2']['claim2']);
-    should.not.exist(testCache['cache']['userId2']['claim3']);
+      should.exist(testCache['cache']['userId2']['claim1']);
+      should.exist(testCache['cache']['userId2']['claim2']);
+      should.exist(testCache['cache']['userId2']['claim3']);
+    });
+
   });
 });

--- a/test/claim_check_cache/remove_outdated_entries.spec.ts
+++ b/test/claim_check_cache/remove_outdated_entries.spec.ts
@@ -1,0 +1,69 @@
+// Note: The tests are accessing private variables, so we must use this type of notation.
+/* eslint-disable dot-notation */
+import * as moment from 'moment';
+import * as should from 'should';
+
+import {ClaimCheckCache} from '../../dist/commonjs/claim_check_cache';
+
+describe('ClaimCheckCache.removeOutdatedEntries()', (): void => {
+
+  let testCache;
+
+  before((): void => {
+    const configToUse = {
+      enabled: true,
+      cacheLifetimeInSeconds: 60,
+      cleanupIntervalInSeconds: 666,
+    };
+
+    testCache = new ClaimCheckCache(configToUse);
+  });
+
+  after((): void => {
+    testCache.disable();
+  });
+
+  it('Should remove all values from the cache that are past the configured expiration time', (): void => {
+
+    const sampleCache = {
+      userId1: {
+        claim1: {
+          userHasClaim: true,
+          lastCheckedAt: moment().add(5, 'seconds'),
+        },
+        claim2: {
+          userHasClaim: false,
+          lastCheckedAt: moment().subtract(120, 'seconds'),
+        },
+      },
+      userId2: {
+        claim1: {
+          userHasClaim: true,
+          lastCheckedAt: moment().subtract(55, 'seconds'),
+        },
+        claim2: {
+          userHasClaim: false,
+          lastCheckedAt: moment(),
+        },
+        claim3: {
+          userHasClaim: false,
+          lastCheckedAt: moment().subtract(61, 'seconds'),
+        },
+      },
+    };
+
+    testCache['cache'] = sampleCache;
+
+    testCache.removeOutdatedEntries();
+
+    should.exist(testCache['cache']['userId1']);
+    should.exist(testCache['cache']['userId2']);
+
+    should.exist(testCache['cache']['userId1']['claim1']);
+    should.not.exist(testCache['cache']['userId1']['claim2']);
+
+    should.exist(testCache['cache']['userId2']['claim1']);
+    should.exist(testCache['cache']['userId2']['claim2']);
+    should.not.exist(testCache['cache']['userId2']['claim3']);
+  });
+});

--- a/test/iam_service/check_if_user_has_claim.spec.ts
+++ b/test/iam_service/check_if_user_has_claim.spec.ts
@@ -1,0 +1,82 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as should from 'should';
+
+import {IAMService} from '../../dist/commonjs/iam_service';
+
+import {ClaimCheckCacheMock, HttpClientMock} from '../mocks';
+
+describe('IamService.checkIfUserHasClaim()', (): void => {
+
+  let iamService;
+
+  beforeEach((): void => {
+    const claimCheckCacheMock = new ClaimCheckCacheMock({enabled: true});
+    const httpClientMock = new HttpClientMock();
+
+    iamService = new IAMService(httpClientMock);
+    iamService.cache = claimCheckCacheMock;
+  });
+
+  it('Should use the result returned from the cache, if the cache does not return undefined', async (): Promise<void> => {
+    iamService.getFromCache = (): any => {
+      return {
+        userHasClaim: true,
+      };
+    };
+
+    iamService.getFromAuthority = (): Promise<any> => {
+      return Promise.resolve(false);
+    };
+
+    const result = await iamService.checkIfUserHasClaim({userId: '123'}, 'claim');
+
+    should(result).be.true();
+  });
+
+  it('Should use the result returned from the authority, if the cache returns undefined', async (): Promise<void> => {
+    iamService.getFromCache = (): any => {
+      return undefined;
+    };
+
+    iamService.getFromAuthority = (): Promise<any> => {
+      return Promise.resolve(false);
+    };
+
+    const result = await iamService.checkIfUserHasClaim({userId: '123'}, 'claim');
+
+    should(result).be.false();
+  });
+
+  it('Should store the result from the authority in the cache', async (): Promise<void> => {
+
+    return new Promise(async (resolve, reject): Promise<void> => {
+      iamService.getFromCache = (): any => {
+        return undefined;
+      };
+
+      iamService.getFromAuthority = (): Promise<any> => {
+        return Promise.resolve(false);
+      };
+
+      const dummyIdentity = {userId: '123'};
+      const dummyClaim = 'claim';
+
+      iamService.cache.add = (userId: string, claimName: string, hasClaim: boolean): void => {
+        try {
+          should(userId).be.equal(dummyIdentity.userId);
+          should(claimName).be.equal(dummyClaim);
+          should(hasClaim).be.false();
+        } catch (error) {
+          reject(error);
+        }
+
+        resolve();
+      };
+
+      const result = await iamService.checkIfUserHasClaim(dummyIdentity, dummyClaim);
+
+      should(result).be.false();
+    });
+  });
+
+});

--- a/test/iam_service/ensure_has_claim.spec.ts
+++ b/test/iam_service/ensure_has_claim.spec.ts
@@ -1,0 +1,96 @@
+import * as should from 'should';
+
+import {BadRequestError, ForbiddenError} from '@essential-projects/errors_ts';
+
+import {IAMService} from '../../dist/commonjs/iam_service';
+
+import {ClaimCheckCacheMock, HttpClientMock} from '../mocks';
+
+describe('IamService.ensureHasClaim()', (): void => {
+
+  let iamService;
+
+  const testIdentity = {
+    userId: 'userId1',
+    token: 'abcdefg',
+  };
+
+  beforeEach((): void => {
+    const claimCheckCacheMock = new ClaimCheckCacheMock({enabled: true});
+    const httpClientMock = new HttpClientMock();
+
+    iamService = new IAMService(httpClientMock);
+    iamService.cache = claimCheckCacheMock;
+    iamService.config = {
+      disableClaimCheck: false,
+    };
+
+    iamService.checkIfUserHasClaim = async (): Promise<boolean> => Promise.resolve(true);
+  });
+
+  describe('Claim checks are enabled', (): void => {
+
+    it('Should resolve without result, if the user has the claim', async (): Promise<void> => {
+      const result = await iamService.ensureHasClaim(testIdentity, 'claim1');
+      should.not.exist(result);
+    });
+
+    it('Should resolve without result, if the dummy token is used', async (): Promise<void> => {
+
+      const dummyIdentity = {
+        userId: 'userId1',
+        token: 'ZHVtbXlfdG9rZW4=',
+      };
+
+      iamService.config.disableClaimCheck = true;
+      const result = await iamService.ensureHasClaim(dummyIdentity, 'claim1');
+      should.not.exist(result);
+    });
+
+    it('Should throw an error, if no identity was provided', async (): Promise<void> => {
+      try {
+        await iamService.ensureHasClaim(undefined, 'claim1');
+      } catch (error) {
+        const expectedError = new BadRequestError('No valid identity given!');
+        should(error).be.eql(expectedError);
+      }
+    });
+
+    it('Should throw an error, if no claim name was provided', async (): Promise<void> => {
+      try {
+        await iamService.ensureHasClaim(testIdentity);
+      } catch (error) {
+        const expectedError = new BadRequestError('No valid claimName given!');
+        should(error).be.eql(expectedError);
+      }
+    });
+
+    it('Should throw an error, if the claim check returns "false"', async (): Promise<void> => {
+      try {
+        iamService.checkIfUserHasClaim = async (): Promise<boolean> => Promise.resolve(false);
+        await iamService.ensureHasClaim(testIdentity, 'claim1');
+      } catch (error) {
+        const expectedError = new ForbiddenError('Identity does not have the requested claim!');
+        should(error).be.eql(expectedError);
+      }
+    });
+
+  });
+
+  describe('Claim checks are disabled', (): void => {
+
+    it('Should resolve without result, even if invalid parameters are provided', async (): Promise<void> => {
+      iamService.config.disableClaimCheck = true;
+      const result = await iamService.ensureHasClaim();
+      should.not.exist(result);
+    });
+
+    it('Should resolve without result', async (): Promise<void> => {
+      iamService.config.disableClaimCheck = true;
+      const result = await iamService.ensureHasClaim(testIdentity, 'claim1');
+      should.not.exist(result);
+    });
+
+  });
+
+});

--- a/test/iam_service/get_from_authority.spec.ts
+++ b/test/iam_service/get_from_authority.spec.ts
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as should from 'should';
+
+import {IAMService} from '../../dist/commonjs/iam_service';
+
+import {ClaimCheckCacheMock, HttpClientMock} from '../mocks';
+
+describe('IamService.getFromAuthority()', (): void => {
+
+  let iamService;
+
+  beforeEach((): void => {
+    const claimCheckCacheMock = new ClaimCheckCacheMock({enabled: true});
+    const httpClientMock = new HttpClientMock();
+
+    iamService = new IAMService(httpClientMock);
+    iamService.cache = claimCheckCacheMock;
+    iamService.config = {
+      claimPath: 'abcdefg',
+    };
+  });
+
+  it('Should correctly return the claim check result received from the authority', async (): Promise<void> => {
+
+    const result = await iamService.getFromAuthority('userId1', 'claim1');
+
+    should(result).be.true();
+  });
+
+});

--- a/test/iam_service/get_from_authority.spec.ts
+++ b/test/iam_service/get_from_authority.spec.ts
@@ -21,9 +21,7 @@ describe('IamService.getFromAuthority()', (): void => {
   });
 
   it('Should correctly return the claim check result received from the authority', async (): Promise<void> => {
-
     const result = await iamService.getFromAuthority('userId1', 'claim1');
-
     should(result).be.true();
   });
 

--- a/test/iam_service/get_from_cache.spec.ts
+++ b/test/iam_service/get_from_cache.spec.ts
@@ -1,0 +1,39 @@
+import * as should from 'should';
+
+import {IAMService} from '../../dist/commonjs/iam_service';
+
+import {ClaimCheckCacheMock, HttpClientMock} from '../mocks';
+
+describe('IamService.getFromCache()', (): void => {
+
+  let iamService;
+
+  beforeEach((): void => {
+    const claimCheckCacheMock = new ClaimCheckCacheMock({enabled: true});
+    const httpClientMock = new HttpClientMock();
+
+    iamService = new IAMService(httpClientMock);
+    iamService.cache = claimCheckCacheMock;
+  });
+
+  it('Should correctly return the claim check result received from the cache', async (): Promise<void> => {
+    const expectedResult = {
+      userHasClaim: false,
+    };
+
+    const result = await iamService.getFromCache('userId1', 'claim1');
+    should(result).be.eql(expectedResult);
+  });
+
+  it('Should return undefined, if the cache is disabled', async (): Promise<void> => {
+    iamService.cache.config.enabled = false;
+    const result = await iamService.getFromCache('userId1', 'claim1');
+    should.not.exist(result);
+  });
+
+  it('Should return undefined, if the cache does not contain a matching value', async (): Promise<void> => {
+    const result = await iamService.getFromCache('userId1', 'claim666');
+    should.not.exist(result);
+  });
+
+});

--- a/test/iam_service/initialize.spec.ts
+++ b/test/iam_service/initialize.spec.ts
@@ -1,0 +1,52 @@
+import * as should from 'should';
+
+import {ClaimCheckCache} from '../../dist/commonjs/claim_check_cache';
+import {IAMService} from '../../dist/commonjs/iam_service';
+
+import {HttpClientMock} from '../mocks';
+
+describe('IamService.initialize()', (): void => {
+
+  const httpClientMock = new HttpClientMock();
+  const iamServiceConfig = {
+    cache: {
+      enabled: false,
+      cacheLifetimeInSeconds: 10,
+      cleanupIntervalInSeconds: 12,
+    },
+  };
+
+  let iamService;
+
+  beforeEach((): void => {
+    iamService = new IAMService(httpClientMock);
+  });
+
+  afterEach((): void => {
+    iamService.cache.disable();
+  });
+
+  it('Should correctly create an instance of the ClaimCheckCache, using the given config', async (): Promise<void> => {
+    iamService.config = iamServiceConfig;
+    await iamService.initialize();
+
+    should(iamService.cache).be.instanceOf(ClaimCheckCache);
+    should(iamService.cache.config).be.eql(iamServiceConfig.cache);
+    should(iamService.cache.enabled).be.false();
+  });
+
+  it('Should correctly create an instance of the ClaimCheckCache, using the cache\'s default config', async (): Promise<void> => {
+    await iamService.initialize();
+
+    const expectedDefaultConfig = {
+      enabled: true,
+      cacheLifetimeInSeconds: 300,
+      cleanupIntervalInSeconds: 120,
+    };
+
+    should(iamService.cache).be.instanceOf(ClaimCheckCache);
+    should(iamService.cache.config).be.eql(expectedDefaultConfig);
+    should(iamService.cache.enabled).be.true();
+  });
+
+});

--- a/test/iam_service/initialize.spec.ts
+++ b/test/iam_service/initialize.spec.ts
@@ -41,7 +41,7 @@ describe('IamService.initialize()', (): void => {
     const expectedDefaultConfig = {
       enabled: true,
       cacheLifetimeInSeconds: 300,
-      cleanupIntervalInSeconds: 120,
+      cleanupIntervalInSeconds: 10,
     };
 
     should(iamService.cache).be.instanceOf(ClaimCheckCache);

--- a/test/identity_service/get_identity.spec.ts
+++ b/test/identity_service/get_identity.spec.ts
@@ -1,0 +1,42 @@
+import * as should from 'should';
+
+import {BadRequestError} from '@essential-projects/errors_ts';
+import {IIdentity} from '@essential-projects/iam_contracts';
+
+import {IdentityService} from '../../dist/commonjs/identity_service';
+
+describe('IdentityService.getIdentity()', (): void => {
+
+  let identityService;
+
+  before((): void => {
+    identityService = new IdentityService();
+  });
+
+  // eslint-disable-next-line
+  const sampleToken = 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjdmNTI3YmM1YjUyZTlmMDM5OGIzZTRkYzE4NmI2ZWE2IiwidHlwIjoiSldUIn0.eyJuYmYiOjE1NjIwNTE4NzksImV4cCI6MTU2MjA1NTQ3OSwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIiwiYXVkIjpbImh0dHA6Ly9sb2NhbGhvc3Q6NTAwMC9yZXNvdXJjZXMiLCJ0ZXN0X3Jlc291cmNlIl0sImNsaWVudF9pZCI6ImJwbW5fc3R1ZGlvIiwic3ViIjoiOThhNDQzNmYtOTk4ZC00YWZhLTkzYWItZTUzYTlhMTA1NTNhIiwiYXV0aF90aW1lIjoxNTYyMDUxODc5LCJpZHAiOiJsb2NhbCIsIkRlZmF1bHRfVGVzdF9MYW5lIjoiMTIzIiwiTGFuZUEiOiJ0cnVlIiwiTGFuZUIiOiJ0cnVlIiwiTGFuZUMiOiJ0cnVlIiwiY2FuX3JlYWRfcHJvY2Vzc19tb2RlbCI6InRydWUiLCJjYW5fd3JpdGVfcHJvY2Vzc19tb2RlbCI6InRydWUiLCJjYW5fY3JlYXRlX2xvY2FsX2FkbWluIjoidHJ1ZSIsIkFnZW50IjoidHJ1ZSIsIm5hbWUiOiJhbGljZSIsInNjb3BlIjpbIm9wZW5pZCIsInByb2ZpbGUiLCJ0ZXN0X3Jlc291cmNlIl0sImFtciI6WyJwd2QiXX0.AroGYUY-kCP3NVfn2-TxwvVvEMN4B97ZxeqR7hse7J-9jatdN1NsmS3Tj_GD7pluBFJmq0sZSHWRL1qk356eTNzgpZCoBCLcgBwoL2s3eFAWrr5V_K4x2PSdbpyFf1_ffdg25_c1WikaPLJElmKTcNoH8M1Bn3bVw4bAt7mOz_9IhGUN5FNjMj4kIEOpY9aN-GHCzhrCwRtj-AwOuEn1Gp9dkmTYwlTALH9-rMCa8SyI5RNL47LaY9cBLp9EBXOfSlDcqe2gxVPC_3EKtbX1sSUf4x9gU0hQlXcQ6TTzFmuyBRtA8IkZXykZq1BNCC2CgurXBoajVh90qPuezKasKA';
+  const dummyToken = 'ZHVtbXlfdG9rZW4=';
+  const sampleInvalidToken = 'invalid';
+
+  it('Should correctly decode the given token and parse it into an IIdentity', async (): Promise<void> => {
+    const parsedIdentity = await identityService.getIdentity(sampleToken);
+    should(parsedIdentity.token).be.equal(sampleToken);
+    should(parsedIdentity.userId).be.equal('98a4436f-998d-4afa-93ab-e53a9a10553a');
+  });
+
+  it('Should correctly decode the given dummy token and parse it into a dummy IIdentity', async (): Promise<void> => {
+    const parsedIdentity = await identityService.getIdentity(dummyToken);
+    should(parsedIdentity.token).be.equal(dummyToken);
+    should(parsedIdentity.userId).be.equal('dummy_token');
+  });
+
+  it('Should throw an error, if getIdentity is called without any parameters', (): void => {
+    const expectedError = new BadRequestError('Must provide a token by which to create an identity!');
+    should((): Promise<IIdentity> => identityService.getIdentity()).throwError(expectedError);
+  });
+
+  it('Should throw an error, if the given token is invalid', (): void => {
+    should((): Promise<IIdentity> => identityService.getIdentity(sampleInvalidToken)).throw();
+  });
+
+});

--- a/test/mocks/claim_check_cache_mock.ts
+++ b/test/mocks/claim_check_cache_mock.ts
@@ -1,34 +1,29 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as moment from 'moment';
 
 export class ClaimCheckCacheMock {
 
   public config: any;
 
-  private cache: any = {
+  public cache: any = {
     userId1: {
       claim1: {
-        userHasClaim: true,
-        lastCheckedAt: moment(),
+        userHasClaim: false,
       },
       claim2: {
-        userHasClaim: false,
-        lastCheckedAt: moment(),
+        userHasClaim: true,
       },
     },
     userId2: {
       claim1: {
-        userHasClaim: false,
-        lastCheckedAt: moment(),
+        userHasClaim: true,
       },
       claim3: {
         userHasClaim: true,
-        lastCheckedAt: moment(),
       },
     },
   };
 
-  constructor(config: any) {
+  constructor(config?: any) {
     this.config = config;
   }
 
@@ -48,11 +43,9 @@ export class ClaimCheckCacheMock {
     if (claimNotCached) {
       this.cache[userId][claimName] = {
         userHasClaim: hasClaim,
-        lastCheckedAt: moment(),
       };
     } else {
       this.cache[userId][claimName].userHasClaim = hasClaim;
-      this.cache[userId][claimName].lastCheckedAt = moment();
     }
   }
 

--- a/test/mocks/claim_check_cache_mock.ts
+++ b/test/mocks/claim_check_cache_mock.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as moment from 'moment';
+
+export class ClaimCheckCacheMock {
+
+  public config: any;
+
+  private cache: any = {
+    userId1: {
+      claim1: {
+        userHasClaim: true,
+        lastCheckedAt: moment(),
+      },
+      claim2: {
+        userHasClaim: false,
+        lastCheckedAt: moment(),
+      },
+    },
+    userId2: {
+      claim1: {
+        userHasClaim: false,
+        lastCheckedAt: moment(),
+      },
+      claim3: {
+        userHasClaim: true,
+        lastCheckedAt: moment(),
+      },
+    },
+  };
+
+  constructor(config: any) {
+    this.config = config;
+  }
+
+  public add(userId: string, claimName: string, hasClaim: boolean): void {
+
+    if (!this.config.enabled) {
+      return;
+    }
+
+    const userIdNotYetCached = !this.cache[userId];
+    if (userIdNotYetCached) {
+      this.cache[userId] = {};
+    }
+
+    const claimNotCached = !this.hasMatchingEntry(userId, claimName);
+
+    if (claimNotCached) {
+      this.cache[userId][claimName] = {
+        userHasClaim: hasClaim,
+        lastCheckedAt: moment(),
+      };
+    } else {
+      this.cache[userId][claimName].userHasClaim = hasClaim;
+      this.cache[userId][claimName].lastCheckedAt = moment();
+    }
+  }
+
+  public get(userId: string, claimName: string): any {
+    if (!this.hasMatchingEntry(userId, claimName)) {
+      return undefined;
+    }
+
+    return this.cache[userId][claimName];
+  }
+
+  public hasMatchingEntry(userId: string, claimName: string): boolean {
+    return this.cache[userId] !== undefined &&
+           this.cache[userId][claimName] !== undefined;
+  }
+
+}

--- a/test/mocks/claim_check_cache_mock.ts
+++ b/test/mocks/claim_check_cache_mock.ts
@@ -27,6 +27,10 @@ export class ClaimCheckCacheMock {
     this.config = config;
   }
 
+  public get enabled(): boolean {
+    return this.config.enabled;
+  }
+
   public add(userId: string, claimName: string, hasClaim: boolean): void {
 
     if (!this.config.enabled) {

--- a/test/mocks/http_client_mock.ts
+++ b/test/mocks/http_client_mock.ts
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export class HttpClientMock {
+
+  private claimConfig: any = {
+    userId1: {
+      claim1: true,
+      claim2: false,
+    },
+    userId2: {
+      claim1: false,
+      claim3: true,
+    },
+  };
+
+  private okResponse = {
+    status: 204,
+  };
+
+  private notOkResponse = {
+    status: 403,
+  };
+
+  public get(url: string, authHeaders: any): any {
+
+    const urlParts = url.split('/')[1];
+    const claimName = urlParts[urlParts.length - 1];
+
+    const userToken = authHeaders.headers.Authorization as string;
+
+    // Remove the "Bearer " prefix
+    const userName = userToken.substring(7);
+
+    if (!this.claimConfig[userName]) {
+      return this.notOkResponse;
+    }
+
+    if (!this.claimConfig[userName][claimName]) {
+      return this.notOkResponse;
+    }
+
+    return this.okResponse;
+  }
+
+}

--- a/test/mocks/http_client_mock.ts
+++ b/test/mocks/http_client_mock.ts
@@ -26,7 +26,7 @@ export class HttpClientMock {
 
   public get(url: string, authHeaders: any): any {
 
-    const urlParts = url.split('/')[1];
+    const urlParts = url.split('/');
     const claimName = urlParts[urlParts.length - 1];
 
     const userToken = authHeaders.headers.Authorization as string;

--- a/test/mocks/http_client_mock.ts
+++ b/test/mocks/http_client_mock.ts
@@ -1,14 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export class HttpClientMock {
 
-  private claimConfig: any = {
+  public claimConfig: any = {
     userId1: {
       claim1: true,
       claim2: false,
+      claim3: true,
+      claim4: false,
     },
     userId2: {
       claim1: false,
-      claim3: true,
+      claim2: true,
+      claim3: false,
+      claim4: true,
     },
   };
 

--- a/test/mocks/index.ts
+++ b/test/mocks/index.ts
@@ -1,0 +1,2 @@
+export * from './claim_check_cache_mock';
+export * from './http_client_mock';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
     "declarationDir": "./dist",
     "sourceMap": true,
     "experimentalDecorators": true
-  }
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
## Changes

1. Implement internal `ClaimCheckCache` for storing the results of a claim check against the authority
    - It can be enabled or disabled through configuration or manually
    - The cache periodically clears out outdated entries
    - The expected config contains the following parameters: 
        - `enabled`: If true, the cache is automatically enabled at startup
        - `cacheLifetimeInSeconds`: The TTL for each cache entry (default is 300 seconds, 0 means the values will never expire)
        - `cleanupIntervalInSeconds`: Interval in which the cache clears out outdated entries (default is 120 seconds, 0 means the cache is never cleared)
    - The config must be stored under `iam:iam_service:cache`
2. IamService uses cached claim check results if available
3. Add `moment` to `dependencies`
4. Add `mocha` and `should` to `devDependencies`
5. Add Unit tests for all components

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/358

PR: #11

## How to test the changes

Run the unit tests to verify the integrity of the cache.

For manual testing:
- Use the IamService with an enabled cache
- Make repeated requests for the same claim check
- Note how only the first will be run against the authority, while all the others use the cache
- Also note how the cache gets invalidated within the configured interval
- After a cache value was invalidated, the next request for the same claim will run against the authority again, the result of which is cached again