### PR TITLE
:lock: Dont allow unlimited access with dummy_token

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Contains the process engines' IAM related functions.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/http_contracts": "^2.3.0",
-    "@essential-projects/iam_contracts": "^3.6.0",
+    "@essential-projects/iam_contracts": "3.6.0-fffd3b04-b2",
     "loggerhythm": "^3.0.3",
     "moment": "^2.24.0"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/http_contracts": "^2.3.0",
-    "@essential-projects/iam_contracts": "3.6.0-fffd3b04-b2",
+    "@essential-projects/iam_contracts": "^3.6.0",
     "loggerhythm": "^3.0.3",
     "moment": "^2.24.0"
   },

--- a/test/iam_service/ensure_has_claim.spec.ts
+++ b/test/iam_service/ensure_has_claim.spec.ts
@@ -23,6 +23,7 @@ describe('IamService.ensureHasClaim()', (): void => {
     iamService.cache = claimCheckCacheMock;
     iamService.config = {
       disableClaimCheck: false,
+      allowGodToken: false,
     };
 
     iamService.checkIfUserHasClaim = async (): Promise<boolean> => Promise.resolve(true);
@@ -87,6 +88,26 @@ describe('IamService.ensureHasClaim()', (): void => {
 
     it('Should resolve without result', async (): Promise<void> => {
       iamService.config.disableClaimCheck = true;
+      const result = await iamService.ensureHasClaim(testIdentity, 'claim1');
+      should.not.exist(result);
+    });
+
+  });
+
+  describe('God token is enabled', (): void => {
+
+    it('Should throw an error, if invalid parameters are provided', async (): Promise<void> => {
+      iamService.config.allowGodToken = true;
+      try {
+        await iamService.ensureHasClaim(undefined, 'claim1');
+      } catch (error) {
+        const expectedError = new BadRequestError('No valid identity given!');
+        should(error).be.eql(expectedError);
+      }
+    });
+
+    it('Should resolve without result', async (): Promise<void> => {
+      iamService.config.allowGodToken = true;
       const result = await iamService.ensureHasClaim(testIdentity, 'claim1');
       should.not.exist(result);
     });


### PR DESCRIPTION
## Changes

This commit will add a new configuration option 'allowGodToken'.
If the 'allowGodToken' option is set to true, the dummy_token
will have unlimited access to all claims.

## Issues

Part of process-engine/process_engine_runtime#414 

PR: #13

---- 

See also: https://github.com/essential-projects/iam_contracts/pull/17
## How to test the changes

> Describe how others can test your changes (not required when fixing typos, linter errors and such)
