### PR TITLE
🔇 Reduce error log spamming for optional claims

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/iam",
-  "version": "1.7.3-alpha.1",
+  "version": "1.7.4",
   "description": "Contains the process engines' IAM related functions.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/iam_service.ts
+++ b/src/iam_service.ts
@@ -8,6 +8,9 @@ import {CacheValue, ClaimCheckCache} from './claim_check_cache';
 
 const logger = Logger.createLogger('processengine:iam:iam_service');
 
+// No logs will be created for any of the claims listed in here.
+const optionalclaims = ['can_manage_process_instances'];
+
 export class IAMService implements IIAMService {
 
   private httpClient: IHttpClient;
@@ -71,7 +74,10 @@ export class IAMService implements IIAMService {
         claimValue: claimValue,
       };
 
-      logger.error('Claim check failed!', error);
+      const isRequiredClaim = !optionalclaims.some((claim) => claim === claimName);
+      if (isRequiredClaim) {
+        logger.error('Claim check failed!', error);
+      }
       throw error;
     }
   }


### PR DESCRIPTION
## Changes

1. Do not log claim check failures for the `can_manage_process_instances` claim
2. Define an internally used list of optional claims, for which no logging will be performed

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/488

PR: #18

## How to test the changes

- Perform claim checks for users that do not have the `can_manage_process_instances` claim
- Note that nothing will be logged